### PR TITLE
chore: remove axios and listner as dev dependencies (used only in loc…

### DIFF
--- a/.github/workflows/cd_publish.yml
+++ b/.github/workflows/cd_publish.yml
@@ -39,26 +39,26 @@ jobs:
           node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
 
-      - name: 🎯 Cache Dependencies
+      - name: 🎯 Cache pnpm dependencies
         uses: actions/cache@v4
-        if: ${{ steps.release.outputs.release_created }}
         with:
-          path: ~/.npm
-          key: npm-linux-${{ hashFiles('packages/tusk/package-lock.json') }}
+          path: ~/.pnpm-store
+          key: pnpm-linux-${{ matrix.node-version }}-${{ hashFiles('packages/tusk/pnpm-lock.yaml') }}
           restore-keys: |
-            npm-linux-
+            pnpm-linux-${{ matrix.node-version }}-
+            pnpm-linux-
 
       - name: 📦 Install Dependencies
         if: ${{ steps.release.outputs.release_created }}
         run: |
           cd packages/tusk
-          npm ci
+          pnpm install
 
       - name: 🏗️ Build
         if: ${{ steps.release.outputs.release_created }}
         run: |
           cd packages/tusk
-          npm run build
+          pnpm run build
 
       - name: 🚀 Publish Package
         if: ${{ steps.release.outputs.release_created }}
@@ -66,4 +66,4 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cd packages/tusk
-          npm publish --access public
+          pnpm run publish --access public

--- a/.github/workflows/cd_publish.yml
+++ b/.github/workflows/cd_publish.yml
@@ -18,6 +18,10 @@ jobs:
     if: github.event.repository.fork == false
     name: 🚀 Release
     steps:
+      - uses: pnpm/action-setup@v4
+        with:
+          version: "9.15.0"
+          
       - name: 🔖 Release on Github
         uses: google-github-actions/release-please-action@v3
         id: release
@@ -43,7 +47,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.pnpm-store
-          key: pnpm-linux-${{ matrix.node-version }}-${{ hashFiles('packages/tusk/pnpm-lock.yaml') }}
+          key: pnpm-linux-${{ matrix.node-version }}-${{ hashFiles("packages/tusk/pnpm-lock.yaml') }}
           restore-keys: |
             pnpm-linux-${{ matrix.node-version }}-
             pnpm-linux-

--- a/.github/workflows/ci_compability-nodejs.yml
+++ b/.github/workflows/ci_compability-nodejs.yml
@@ -16,8 +16,8 @@ jobs:
     steps:
       - uses: pnpm/action-setup@v4
         with:
-          version: "9.15.0"
-          
+          version: "6.32.20"
+
       - name: 📥 Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/ci_compability-nodejs.yml
+++ b/.github/workflows/ci_compability-nodejs.yml
@@ -22,21 +22,21 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       
-      - name: 🎯 Cache Dependencies
+      - name: 🎯 Cache pnpm dependencies
         uses: actions/cache@v4
         with:
-          path: ~/.npm
-          key: npm-linux-${{ matrix.node-version }}-${{ hashFiles('packages/tusk/package-lock.json') }}
+          path: ~/.pnpm-store
+          key: pnpm-linux-${{ matrix.node-version }}-${{ hashFiles('packages/tusk/pnpm-lock.yaml') }}
           restore-keys: |
-            npm-linux-${{ matrix.node-version }}-
-            npm-linux-
+            pnpm-linux-${{ matrix.node-version }}-
+            pnpm-linux-
 
       - name: 📦 Install Dependencies
         run: |
           cd packages/tusk
-          npm ci
+          pnpm install
       
       - name: 🧪 Run Tests
         run: |
           cd packages/tusk
-          npm run test
+          pnpm run test

--- a/.github/workflows/ci_compability-nodejs.yml
+++ b/.github/workflows/ci_compability-nodejs.yml
@@ -14,6 +14,10 @@ jobs:
         node-version: ["14", "16", "18", "20", "22", "23"]
     name: Node.js ${{ matrix.node-version }}
     steps:
+      - uses: pnpm/action-setup@v4
+        with:
+          version: "9.15.0"
+          
       - name: 📥 Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/ci_compability-nodejs.yml
+++ b/.github/workflows/ci_compability-nodejs.yml
@@ -11,12 +11,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["14", "16", "18", "20", "22", "23"]
+        node-version: ["18", "20", "22", "23"]
     name: Node.js ${{ matrix.node-version }}
     steps:
       - uses: pnpm/action-setup@v4
         with:
-          version: "6.32.20"
+          version: "9.15.0"
 
       - name: 📥 Checkout
         uses: actions/checkout@v4

--- a/apps/docs/content/docs/index.pt.mdx
+++ b/apps/docs/content/docs/index.pt.mdx
@@ -6,7 +6,7 @@ import { DynamicLink } from "fumadocs-core/dynamic-link";
 
 <div className="w-full flex items-center justify-center"><span className="text-4xl font-bold">🦣 O que é o Tusk?</span></div>
 
-Tusk é sua biblioteca JavaScript definitiva, leve e poderosa para modificação dinâmica de código através de <DynamicLink href="/docs/monkey-patching">monkey-patching</DynamicLink>. 
+Tusk é sua biblioteca JavaScript definitiva, leve e poderosa para modificação dinâmica de código através de <DynamicLink href="/[lang]/docs/monkey-patching">monkey-patching</DynamicLink>. 
 Seja para corrigir bugs, estender funcionalidades ou otimizar performance, Tusk oferece uma maneira limpa, segura e elegante de aprimorar suas aplicações.
 
 ---

--- a/packages/tusk/package.json
+++ b/packages/tusk/package.json
@@ -8,7 +8,7 @@
     "build": "tsup",
     "dev": "tsx --watch playground/index.ts",
     "publish": "npm publish",
-    "test": "npx poku --sequential --watch"
+    "test": "npx poku --sequential"
   },
   "keywords": [
     "tusk",

--- a/packages/tusk/package.json
+++ b/packages/tusk/package.json
@@ -42,7 +42,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "listner": "^1.1.1",
     "poku": "^3.0.1",
     "tsup": "^8.4.0",
     "tsx": "^4.19.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,9 +111,6 @@ importers:
 
   packages/tusk:
     devDependencies:
-      listner:
-        specifier: ^1.1.1
-        version: 1.1.1
       poku:
         specifier: ^3.0.1
         version: 3.0.1
@@ -2684,10 +2681,6 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  listner@1.1.1:
-    resolution: {integrity: sha512-vIMbRs/8c/VXd2oshPKXK0MeNlGHC57UAqvofMTDvlisZLu+d0nrrvpXoowZYm+9+SjsJbo62+SWxfediK0+HQ==}
-    deprecated: This package has been discontinued and is no longer maintained. Please consider alternative solutions or libraries for your project. Thank you for your understanding.
-
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2951,6 +2944,7 @@ packages:
   nanoid@3.3.8:
     resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -6851,8 +6845,6 @@ snapshots:
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
-
-  listner@1.1.1: {}
 
   load-tsconfig@0.2.5: {}
 


### PR DESCRIPTION
## Description
This PR removes `axios` and `listner` from the dev dependencies since they were only used in local tests. This helps keep the project cleaner and more efficient.

## Changes
- Removed `axios` and `listner` from `devDependencies` in `package.json`.
- Updated the project to reflect these changes.

## Impact
- **Cleaner dependencies**: Reduces unnecessary packages in the project.
- **Efficiency**: Improves installation and build times by removing unused dependencies.

## Warning
⚠️ **Note**: This branch contains 8 commits, some of which are fixes rather than feature changes. This is due to iterative adjustments during development. Please review the commit history for details.