### PR TITLE
ci: use bin instead of `npx` to run tests

### DIFF
--- a/packages/tusk/package.json
+++ b/packages/tusk/package.json
@@ -8,7 +8,7 @@
     "build": "tsup",
     "dev": "tsx --watch playground/index.ts",
     "publish": "npm publish",
-    "test": "npx poku --sequential"
+    "test": "poku --sequential"
   },
   "keywords": [
     "tusk",


### PR DESCRIPTION
Hey, @ofabiodev! Thanks for use **Poku** 🐷✨

I've made a really simple adjustment by removing `npx` from _package.json_ scripts. It removes the `npx` overhead by running the script directly from the binary (_node_modules/.bin/poku_).

- **[OFF]** Apart, I thought **Tusk** very cute 🦣
